### PR TITLE
Update yargs dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1716,7 +1716,7 @@
             "replace-homedir": "^1.0.0",
             "semver-greatest-satisfied-range": "^1.1.0",
             "v8flags": "^3.2.0",
-            "yargs": "^7.1.0"
+            "yargs": "^18.1.1"
           }
         }
       }


### PR DESCRIPTION
Fix low security alert by updating yargs to the latest version.