### PR TITLE
Fix imports to be esModuleInteropt compliant, remove error log test

### DIFF
--- a/src/daos/ParentDao.ts
+++ b/src/daos/ParentDao.ts
@@ -1,4 +1,4 @@
-import * as oracledb from "oracledb";
+import oracledb from "oracledb";
 import config from "../config";
 import { createLogger } from "ch-structured-logging";
 

--- a/src/test/BarcodeSearchController.test.ts
+++ b/src/test/BarcodeSearchController.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import chai from 'chai';
+import sinon from 'sinon';
 import BarcodeSearchController from '../controllers/BarcodeSearchController';
 import ChipsDao from '../daos/CHIPS/ChipsDao';
 chai.use(require('sinon-chai'));

--- a/src/test/BarcodeSearchRouter.test.ts
+++ b/src/test/BarcodeSearchRouter.test.ts
@@ -1,7 +1,6 @@
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as express from "express";
-import BarcodeSearchController from '../controllers/BarcodeSearchController';
+import chai from 'chai';
+import sinon from 'sinon';
+import express from "express";
 import BarcodeSearchRouter from '../routes/BarcodeSearchRouter';
 chai.use(require('sinon-chai'));
 

--- a/src/test/ChipsDao.test.ts
+++ b/src/test/ChipsDao.test.ts
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
-import * as sinon from 'sinon';
-import * as oracledb from 'oracledb';
+import sinon from 'sinon';
+import oracledb from 'oracledb';
 import ChipsDao from '../daos/CHIPS/ChipsDao';
+
 
 const config = {
     user: "USER",
@@ -45,14 +46,13 @@ describe('Chips database call', () => {
         expect(result).to.equal(undefined);
     })
 
-    it('test execute throws an error, result is set to null and error is logged', async () => {
-        const consoleStub = sinon.stub(console, 'log');
+    it('test execute throws an error, result is set to null', async () => {
+
         let connection = await oracledb.getConnection(config);
         connection.execute.throws(error);
         let result = await chipsDao.makeQuery(INCORRECT_BARCODE, ["bind value 1"]);
         expect(connection.execute).to.have.throw(error);
         expect(result).to.not.equal(undefined);
         expect(result).to.equal(null);
-        expect(consoleStub.calledOnce).to.be.true;
     })
 });


### PR DESCRIPTION
This PR changes imports in ts files to be compliant with the tsconfig setting of esModuleInteropt: true. Also the console log check in the ChipsDao test was removed as this was changed for a logger, sinon does not support stubbing stand alone functions and the prototype call for the ApplicationLogger can't be overwritten.
