### PR TITLE
Add error message to barcode search

### DIFF
--- a/src/controllers/BarcodeSearchController.ts
+++ b/src/controllers/BarcodeSearchController.ts
@@ -41,7 +41,7 @@ class BarcodeSearchController {
             userLogin = await this.chipsService.getUserFromId(staffwareResult.userId);
         }
 
-        if (chipsResult.transactionId == undefined && fesResult.envNo == undefined) {
+        if (chipsResult.isEmpty() && fesResult.isEmpty()) {
             res.render("barcodeSearch", {
                 barcode: barcode,
                 error: true

--- a/src/data/ChipsResult.ts
+++ b/src/data/ChipsResult.ts
@@ -4,6 +4,10 @@ class ChipsResult {
     incorporationNumber: string;
     chipsStatus: string;
     transactionDate: string;
+
+    public isEmpty() {
+        return Object.keys(this).length === 0;
+    }
 }
 
 export default ChipsResult;

--- a/src/data/FesResult.ts
+++ b/src/data/FesResult.ts
@@ -8,6 +8,10 @@ class FesResult {
     exceptionId: number;
     eventOccurredTime: string;
     eventText: string;
+
+    public isEmpty() {
+        return Object.keys(this).length === 0;
+    }
 }
 
 export default FesResult;

--- a/src/service/FesService.ts
+++ b/src/service/FesService.ts
@@ -13,7 +13,6 @@ class FesService {
         var result = new FesResult();
         var fesSearch = await this.dao.makeQuery(SqlData.fesTransactionSql, [barcode]);
         if (fesSearch.rows[0]) {
-            console.log(fesSearch.rows[0]);
             result.envNo = fesSearch.rows[0]['FORM_ENVELOPE_ID'];
             result.scanTime = fesSearch.rows[0]['FORM_BARCODE_DATE'];
             result.formType = fesSearch.rows[0]['FORM_TYPE'];

--- a/src/service/FesService.ts
+++ b/src/service/FesService.ts
@@ -12,21 +12,23 @@ class FesService {
     public async getTransactionDetailsFromBarcode(barcode: string): Promise<FesResult> {
         var result = new FesResult();
         var fesSearch = await this.dao.makeQuery(SqlData.fesTransactionSql, [barcode]);
-        console.log(fesSearch.rows[0]);
-        result.envNo = fesSearch.rows[0]['FORM_ENVELOPE_ID'];
-        result.scanTime = fesSearch.rows[0]['FORM_BARCODE_DATE'];
-        result.formType = fesSearch.rows[0]['FORM_TYPE'];
-        result.fesStatus = fesSearch.rows[0]['FORM_STATUS_TYPE_NAME'];
-        result.icoReturnedReason = fesSearch.rows[0]['IMAGE_EXCEPTION_REASON'] || "No image exception returned";
-        result.icoAction = fesSearch.rows[0]['IMAGE_EXCEPTION_FREE_TEXT'] || "No image exception returned";
-        result.exceptionId = fesSearch.rows[0]['IMAGE_EXCEPTION_ID'];
-        if (result.exceptionId) {
-            var exceptionSearch = await this.dao.makeQuery(SqlData.fesRescannedSql, [result.exceptionId]);
-            result.eventOccurredTime = exceptionSearch.rows[0]['FORM_EVENT_OCCURED'] || "No event yet";
-            result.eventText = exceptionSearch.rows[0]['FORM_EVENT_TEXT'] || "No event yet";
-        } else {
-            result.eventOccurredTime = "No exception occurred";
-            result.eventText = "No exception occurred";
+        if (fesSearch.rows[0]) {
+            console.log(fesSearch.rows[0]);
+            result.envNo = fesSearch.rows[0]['FORM_ENVELOPE_ID'];
+            result.scanTime = fesSearch.rows[0]['FORM_BARCODE_DATE'];
+            result.formType = fesSearch.rows[0]['FORM_TYPE'];
+            result.fesStatus = fesSearch.rows[0]['FORM_STATUS_TYPE_NAME'];
+            result.icoReturnedReason = fesSearch.rows[0]['IMAGE_EXCEPTION_REASON'] || "No image exception returned";
+            result.icoAction = fesSearch.rows[0]['IMAGE_EXCEPTION_FREE_TEXT'] || "No image exception returned";
+            result.exceptionId = fesSearch.rows[0]['IMAGE_EXCEPTION_ID'];
+            if (result.exceptionId) {
+                var exceptionSearch = await this.dao.makeQuery(SqlData.fesRescannedSql, [result.exceptionId]);
+                result.eventOccurredTime = exceptionSearch.rows[0]['FORM_EVENT_OCCURED'] || "No event yet";
+                result.eventText = exceptionSearch.rows[0]['FORM_EVENT_TEXT'] || "No event yet";
+            } else {
+                result.eventOccurredTime = "No exception occurred";
+                result.eventText = "No exception occurred";
+            }
         }
         return result;
     }

--- a/src/views/barcodeSearch.html
+++ b/src/views/barcodeSearch.html
@@ -6,6 +6,9 @@
         <div class="govuk-form-group">
             <input type="search" name="search" id="search" class="govuk-input">
             <input type="submit" class="govuk-button">
+            {% if error %}
+                <span id="barcode-error" class="govuk-error-message">No results found.</span>
+            {% endif %}
         </div>
     </form>
 {% endblock %}


### PR DESCRIPTION
This PR adds an error message to the barcodeSearch page that is shown when no result is retrieved from either CHIPS or FES databases. In the case that a result is retrieved from one of them the documentOverview page will be rendered instead.

**Resolves**
- BI-6702