### PR TITLE
Add FES admin log in

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,20 +14,26 @@
   "author": "companieshouse",
   "license": "MIT",
   "dependencies": {
-    "@types/node": "^14.14.6",
     "@types/express": "~4.17.6",
+    "@types/express-session": "^1.17.3",
+    "@types/node": "^14.14.6",
+    "body-parser": "^1.19.0",
+    "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#1.0.0",
+    "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
+    "cookie-parser": "~1.4.4",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "express-session": "^1.17.1",
     "govuk-frontend": "^3.9.1",
     "gulp": "^4.0.2",
+    "gulp-cli": "^2.3.0",
     "gulp-sass": "^4.1.0",
+    "mongodb": "^3.6.5",
     "nodemon": "^2.0.6",
     "nunjucks": "^3.2.2",
     "oracledb": "^5.0.0",
     "ts-node": "^9.0.0",
-    "gulp-cli": "^2.3.0",
-    "typescript": "^4.0.3",
-    "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2"
+    "typescript": "^4.0.3"
   },
   "nodemonConfig": {
     "watch": [
@@ -44,6 +50,7 @@
     "mocha": "^8.2.0",
     "sinon": "^9.2.1",
     "sinon-chai": "^3.5.0",
-    "ts-mocha": "^8.0.0"
+    "ts-mocha": "^8.0.0",
+    "proxyquire": "^2.1.3"
   }
 }

--- a/src/ApplicationConfiguration.ts
+++ b/src/ApplicationConfiguration.ts
@@ -2,6 +2,7 @@ interface ApplicationConfiguration {
     port: number;
     urlPrefix: string;
     applicationNamespace: string;
+    mongodb: string;
     chipsDatabase: {
         username: string;
         password: string;
@@ -16,6 +17,12 @@ interface ApplicationConfiguration {
         username: string;
         password: string;
         connectionString: string;
+    };
+    session: {
+        cookieName: string;
+        cookieSecret: string;
+        cookieDomain: string;
+        cacheServer: string;
     };
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,16 @@
 import express from "express";
+import session from "express-session";
+import genuuid from "uuid/v4";
 import { createLogger, createLoggerMiddleware } from "ch-structured-logging";
 import * as nunjucks from "nunjucks";
 import config from "./config";
 import path from "path";
+import Redis from "ioredis";
 
 import BarcodeSearchRouter from "./routes/BarcodeSearchRouter";
+import authenticationMiddleware from "./controllers/Authentication";
+import SigninRouter from "./routes/SigninRouter";
+import cookieParser from "cookie-parser";
 
 const app = express();
 const logger = createLogger(config.applicationNamespace);
@@ -24,10 +30,28 @@ var env = nunjucks
 
 app.set("views", viewPath);
 app.set("view engine", "html");
-
 app.use(`/${config.urlPrefix}/static`, express.static("dist/static"));
 env.addGlobal("CSS_URL", `/${config.urlPrefix}/static/app.css`);
 
+app.use(cookieParser());
+
+app.use(session({
+    name: config.session.cookieName,
+    secret: config.session.cookieSecret,
+    genid: function(req) { return genuuid(); },
+    cookie: { 
+        secure: false,
+        expires: new Date(Date.now() + 3600000),
+        httpOnly: true,
+        domain: config.session.cookieDomain
+    },
+    store: new Redis(`redis://${config.session.cacheServer}`),
+    resave: false,
+    saveUninitialized: true,
+}));
+app.use(`/${config.urlPrefix}`, SigninRouter.create());
+
+app.use(authenticationMiddleware());
 app.use(`/${config.urlPrefix}`, BarcodeSearchRouter.create());
 app.use(createLoggerMiddleware(config.applicationNamespace));
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -40,7 +40,7 @@ app.use(session({
     secret: config.session.cookieSecret,
     genid: function(req) { return genuuid(); },
     cookie: { 
-        secure: false,
+        secure: true,
         expires: new Date(Date.now() + 3600000),
         httpOnly: true,
         domain: config.session.cookieDomain

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,8 @@ const config: ApplicationConfiguration = {
     port: parseInt(process.env.PORT as string),
     urlPrefix: "transactionsearch",
     applicationNamespace: "transaction-search-tool",
+    mongodb: process.env.MONGODB_URL as string,
+    
     chipsDatabase: {
         username: process.env.CHIPS_DB_USER as string,
         password: process.env.CHIPS_DB_PASSWORD as string,
@@ -18,7 +20,13 @@ const config: ApplicationConfiguration = {
         username: process.env.FES_DB_USER as string,
         password: process.env.FES_DB_PASSWORD as string,
         connectionString: process.env.FES_DB_CONNECTIONSTRING as string
-    }
+    },
+    session: {
+        cookieName: process.env.COOKIE_NAME as string,
+        cookieSecret: process.env.COOKIE_SECRET as string,
+        cookieDomain: process.env.COOKIE_DOMAIN as string,
+        cacheServer: process.env.CACHE_SERVER as string
+    },
 };
 
 export default config;

--- a/src/controllers/Authentication.ts
+++ b/src/controllers/Authentication.ts
@@ -1,0 +1,35 @@
+import { RequestHandler } from "express";
+import { SessionKey } from "ch-node-session-handler/lib/session/keys/SessionKey";
+import { SignInInfoKeys } from "ch-node-session-handler/lib/session/keys/SignInInfoKeys";
+import { UserProfileKeys } from "ch-node-session-handler/lib/session/keys/UserProfileKeys";
+import config from "../config";
+import { createLogger } from "ch-structured-logging";
+
+const logger = createLogger(config.applicationNamespace);
+
+const createAuthenticationMiddleware = function (): RequestHandler {
+
+    return (req, res, next) => {
+
+        const signInInfo = req.session[SessionKey.SignInInfo];
+        if (signInInfo !== undefined) {
+
+            const signedIn = signInInfo[SignInInfoKeys.SignedIn] === 1;
+            const userInfo = signInInfo[SignInInfoKeys.UserProfile];
+
+            if (signedIn && userInfo !== undefined) {
+                if (req.body === undefined) {
+                    req.body = {};
+                }
+
+                req.body.loggedInUserEmail = userInfo[UserProfileKeys.Email];
+                logger.info(req.body.loggedInUserEmail);
+                return next();
+            }
+        }
+
+        return res.redirect(`/signin?return_to=/${config.urlPrefix}`);
+    };
+};
+
+export default createAuthenticationMiddleware;

--- a/src/controllers/SigninController.ts
+++ b/src/controllers/SigninController.ts
@@ -2,6 +2,8 @@ import SigninDao from "../daos/Mongo/SigninDao";
 import { SessionKey } from "ch-node-session-handler/lib/session/keys/SessionKey";
 import { SignInInfoKeys } from "ch-node-session-handler/lib/session/keys/SignInInfoKeys";
 
+// For node environments only, not to be used in live. Live will
+// use the CHS login and read the login data from the session.
 class SigninController {
 
     signinDao:SigninDao;

--- a/src/controllers/SigninController.ts
+++ b/src/controllers/SigninController.ts
@@ -1,0 +1,41 @@
+import SigninDao from "../daos/Mongo/SigninDao";
+import { SessionKey } from "ch-node-session-handler/lib/session/keys/SessionKey";
+import { SignInInfoKeys } from "ch-node-session-handler/lib/session/keys/SignInInfoKeys";
+
+class SigninController {
+
+    signinDao:SigninDao;
+
+    constructor() {
+        this.signinDao = new SigninDao();
+    }
+
+    public getSigninPage(req: any, res: any) {
+        res.render("signin");
+    }
+
+    public async submitSignin(req: any, res: any) {
+        var username = req.body.username;
+        var password = req.body.password;
+        var result = await this.signinDao.checkSignin(username);
+        
+        if (result !== undefined && result.password === password) {
+            this.populateSession(req, result);
+            res.redirect("barcodeSearch");
+        } else {
+            res.render("signin", {
+                error: true
+            });
+        }
+    }
+
+    private populateSession(req, result) {
+        req.session[SessionKey.SignInInfo] = { 
+            [SignInInfoKeys.SignedIn]: 1,
+            [SignInInfoKeys.UserProfile]: result
+        };
+        return
+    }
+}
+
+export default SigninController;

--- a/src/daos/Mongo/SigninDao.ts
+++ b/src/daos/Mongo/SigninDao.ts
@@ -23,10 +23,8 @@ class SigninDao {
         finally {
             await client.close();
         }
-    return result;
+        return result;
     }
-
-
 }
 
 export default SigninDao;

--- a/src/daos/Mongo/SigninDao.ts
+++ b/src/daos/Mongo/SigninDao.ts
@@ -1,0 +1,32 @@
+import config from "../../config";
+import { createLogger } from "ch-structured-logging";
+import { MongoClient } from "mongodb";
+
+const logger = createLogger(config.applicationNamespace);
+
+class SigninDao {
+
+    public async checkSignin(username: string) {
+        const client = new MongoClient(config.mongodb);
+        var result;
+
+        try {
+            await client.connect();
+            const database = client.db('account');
+            const users = database.collection('users');
+
+            result = await users.findOne({ email: username });
+            logger.info(`result found for email: ${username}`);
+        } catch(error){
+            logger.error(error);
+        }
+        finally {
+            await client.close();
+        }
+    return result;
+    }
+
+
+}
+
+export default SigninDao;

--- a/src/routes/BarcodeSearchRouter.ts
+++ b/src/routes/BarcodeSearchRouter.ts
@@ -9,6 +9,7 @@ class BarcodeSearchRouter {
         var barcodeSearchController = new BarcodeSearchController();
 
         router.get("/", (req, res) => barcodeSearchController.getSearchPage(req, res));
+        router.get("/barcodeSearch", (req, res) => barcodeSearchController.getSearchPage(req, res));
         router.get("/search", (req, res) => barcodeSearchController.searchBarcode(req, res));
 
         return router;

--- a/src/routes/SigninRouter.ts
+++ b/src/routes/SigninRouter.ts
@@ -1,0 +1,19 @@
+import SigninController from '../controllers/SigninController';
+import * as express from "express";
+import bodyParser from "body-parser";
+
+
+class SigninRouter {
+
+    public static create() {
+        const router = express.Router();
+
+        var signinController = new SigninController();
+
+        router.get("/signin", (req, res) => signinController.getSigninPage(req, res));
+        router.post("/signin", bodyParser.urlencoded({extended:false}), (req, res) => signinController.submitSignin(req, res));
+        return router;
+    }
+}
+
+export default SigninRouter;

--- a/src/test/controllers/Authentication.test.ts
+++ b/src/test/controllers/Authentication.test.ts
@@ -1,0 +1,98 @@
+import sinon from "sinon";
+
+import { ISignInInfo } from "ch-node-session-handler/lib/session/model/SessionInterfaces";
+import { RequestHandler } from "express";
+import { SignInInfoKeys } from "ch-node-session-handler/lib/session/keys/SignInInfoKeys";
+import { SessionKey } from "ch-node-session-handler/lib/session/keys/SessionKey";
+import { UserProfileKeys } from "ch-node-session-handler/lib/session/keys/UserProfileKeys";
+
+import chai from 'chai';
+
+const proxyquire = require("proxyquire");
+
+describe("authenticationMiddleware", function () {
+
+    const createMockRequest = function (signInInfo?: ISignInInfo) {
+        return {
+            session: {
+                [SessionKey.SignInInfo]: signInInfo
+            },
+        };
+    };
+
+    const createMockResponse = function () {
+        return {
+            redirect: sinon.spy(),
+            status: sinon.stub(),
+            render: sinon.spy()
+        };
+    };
+
+    let next: any;
+
+    let middleware: RequestHandler;
+
+    const requireMiddleware = function () {
+
+        return proxyquire("../../controllers/Authentication", {
+            "ch-structured-logging": {
+                createLogger: function () {
+                    return { 
+                        info: sinon.stub(),
+                        error: sinon.stub()
+                     };
+                }
+            },
+            "../config": {
+                default: {
+
+                }
+            }
+        }).default();
+    };
+
+    beforeEach(function () {
+        next = sinon.stub();
+        middleware = requireMiddleware();
+    });
+
+
+    it("redirects to signin if session does not exist", function () {
+
+        const mockRequest: any = createMockRequest();
+        const mockResponse: any = createMockResponse();
+
+        middleware(mockRequest, mockResponse, next);
+
+        chai.expect(mockResponse.redirect.calledOnceWith("signin")).to.be.true;
+    });
+
+    it("calls next if signed in and user profile exists", function () {
+
+        const mockRequest: any = createMockRequest({
+            [SignInInfoKeys.SignedIn]: 1,
+                [SignInInfoKeys.UserProfile]: {
+                    [UserProfileKeys.Email]: 'email',
+                }
+        });
+        const mockResponse: any = createMockResponse();
+
+        middleware(mockRequest, mockResponse, next);
+
+        chai.expect(next.calledOnce).to.be.true;
+    });
+    it("redirects to signin if signed in is set to 0", function () {
+
+        const mockRequest: any = createMockRequest({
+            [SignInInfoKeys.SignedIn]: 0,
+                [SignInInfoKeys.UserProfile]: {
+                    [UserProfileKeys.Email]: 'email',
+                }
+        });
+        const mockResponse: any = createMockResponse();
+
+        middleware(mockRequest, mockResponse, next);
+
+        chai.expect(mockResponse.redirect.calledOnceWith("signin")).to.be.true;
+    });
+});

--- a/src/test/controllers/SigninController.test.ts
+++ b/src/test/controllers/SigninController.test.ts
@@ -1,0 +1,58 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import SigninController from '../../controllers/SigninController';
+import SigninDao from '../../daos/Mongo/SigninDao';
+
+chai.use(require('sinon-chai'));
+
+describe('sign in controller', ()=>{
+
+    const req = {
+        session: {},
+        body: {
+            username: 'name',
+            password: 'password'
+        }
+    }
+
+    const wrongReq = {
+        session: {},
+        body: {
+            username: 'wrong',
+            password: 'wrong'
+        }
+    }
+    const res = {
+        render: sinon.spy(),
+        redirect: sinon.spy()
+    };
+
+    var signinController: SigninController;
+
+    before(()=>{
+
+        signinController = new SigninController();
+        let signinDao = new SigninDao();
+
+        var result = {
+            name: 'name',
+            password: 'password'
+        }
+
+        sinon.stub(signinDao, 'checkSignin').resolves(result);
+        signinController.signinDao = signinDao;
+    })
+
+    it('test getSigninPage calls response render', ()=>{
+        signinController.getSigninPage(req, res);
+        chai.expect(res.render.calledOnce).to.be.true;
+    })
+
+    it('test submitSignin calls response redirect method with barcodeSearch when correct credentials are passed and render signin when not', async ()=>{
+
+        await signinController.submitSignin(req, res);
+        chai.expect(res.redirect.calledWithMatch("barcodeSearch")).to.be.true;
+        await signinController.submitSignin(wrongReq, res);
+        chai.expect(res.render.calledWithMatch("signin")).to.be.true;
+    }).timeout(5000)
+})

--- a/src/test/routes/BarcodeSearchRouter.test.ts
+++ b/src/test/routes/BarcodeSearchRouter.test.ts
@@ -17,6 +17,7 @@ describe('barcode search router', ()=>{
     it('test that search is called', ()=>{
         BarcodeSearchRouter.create();
         chai.expect(spy.getCall(0).calledWithMatch('/')).to.be.true;
-        chai.expect(spy.getCall(1).calledWithMatch('/search')).to.be.true;
+        chai.expect(spy.getCall(1).calledWithMatch('/barcodeSearch')).to.be.true;
+        chai.expect(spy.getCall(2).calledWithMatch('/search')).to.be.true;
     })
 })

--- a/src/test/routes/SiginRouter.test.ts
+++ b/src/test/routes/SiginRouter.test.ts
@@ -1,0 +1,25 @@
+import chai from 'chai';
+import sinon, { SinonSpy } from 'sinon';
+import express, { Router } from "express";
+import SigninRouter from '../../routes/SigninRouter';
+chai.use(require('sinon-chai'));
+
+describe('sign in router', ()=>{
+    let router: Router;
+    let getSpy: SinonSpy;
+    let postSpy: SinonSpy;
+    before(()=>{
+        getSpy = sinon.spy();
+        postSpy = sinon.spy();
+        router = express.Router();
+        router.get = getSpy;
+        router.post = postSpy;
+        express.Router = () => router;
+    });
+
+    it('test that sign in is called with /signin get and post', ()=>{
+        SigninRouter.create();
+        chai.expect(getSpy.getCall(0).calledWithMatch('/signin')).to.be.true;
+        chai.expect(postSpy.getCall(0).calledWithMatch('/signin')).to.be.true;
+    })
+})

--- a/src/views/signin.html
+++ b/src/views/signin.html
@@ -1,0 +1,58 @@
+{% extends "layout.html" %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <h1 class="govuk-heading-l">Sign in</h1>
+        <h2 class="govuk-heading-m">FES Admin System</h2>
+        
+        <form method="POST" action="/transactionsearch/signin">
+            <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" data-required="data-required" data-error="Enter your username">
+                <legend>
+                <label class="govuk-label" for="username">
+                    Username
+                </label>
+                </legend>
+                <input class="govuk-input govuk-!-width-two-thirds" id="username" name="username" type="text" required>
+            </fieldset>
+            </div>
+            <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" data-required="data-required" data-error="Enter your password">
+                <legend>
+                <label class="govuk-label" for="chs-password">
+                    Password
+                </label>
+                </legend>
+                <input class="govuk-input govuk-!-width-two-thirds" id="password" name="password" type="password" required>
+            </fieldset>
+            </div>
+                <input type="submit" class="govuk-button" value="Sign in" />
+                {% if error %}
+                    <span id="barcode-error" class="govuk-error-message">Email or password not recognised.</span>
+                {% endif %}
+            </div>
+        </form>
+
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    Help with registering
+                </span>
+            </summary>
+            <div class="govuk-details__text">
+                A manager must authorise access by raising a request via service now.
+            </div>
+        </details>
+
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    Forgotten your password?
+                </span>
+            </summary>
+            <div class="govuk-details__text">
+                The front end support team will be able to help. They are available 9 - 5, Monday - Friday.
+            </div>
+        </details>
+    </div>
+{% endblock %}


### PR DESCRIPTION
This PR adds the session and authentication middleware that will check the session for a signed in value and user profile. If these are blank or signed in is set to 0 it will redirect to CHS login. Additionally a sign in page is added for use in node environments with its own router. The router is called before the middleware in app.ts allowing to populate the session with sign in information before running through the middleware and being redirected to CHS.

**Resolves:**
- BI-7192