### PR TITLE
Change auth test to use check CHS sign in

### DIFF
--- a/src/test/controllers/Authentication.test.ts
+++ b/src/test/controllers/Authentication.test.ts
@@ -32,6 +32,8 @@ describe("authenticationMiddleware", function () {
 
     let middleware: RequestHandler;
 
+    let mockUrl = "transactionsearch";
+
     const requireMiddleware = function () {
 
         return proxyquire("../../controllers/Authentication", {
@@ -45,7 +47,7 @@ describe("authenticationMiddleware", function () {
             },
             "../config": {
                 default: {
-
+                    urlPrefix:mockUrl
                 }
             }
         }).default();
@@ -64,7 +66,7 @@ describe("authenticationMiddleware", function () {
 
         middleware(mockRequest, mockResponse, next);
 
-        chai.expect(mockResponse.redirect.calledOnceWith("signin")).to.be.true;
+        chai.expect(mockResponse.redirect.calledOnceWith(`/signin?return_to=/${mockUrl}`)).to.be.true;
     });
 
     it("calls next if signed in and user profile exists", function () {
@@ -93,6 +95,6 @@ describe("authenticationMiddleware", function () {
 
         middleware(mockRequest, mockResponse, next);
 
-        chai.expect(mockResponse.redirect.calledOnceWith("signin")).to.be.true;
+        chai.expect(mockResponse.redirect.calledOnceWith(`/signin?return_to=/${mockUrl}`)).to.be.true;
     });
 });


### PR DESCRIPTION
This PR fixes the Authentication test which used to point to the node environment signin page  to redirect to CHS sign in.

**Resolves**
- BI-7192