### PR TITLE
Add user permission check and not authorised page

### DIFF
--- a/src/controllers/Authentication.ts
+++ b/src/controllers/Authentication.ts
@@ -25,7 +25,18 @@ const createAuthenticationMiddleware = function (): RequestHandler {
                 }
                 req.body.loggedInUserEmail = userInfo[UserProfileKeys.Email];
                 logger.info(`Logged in as: ${req.body.loggedInUserEmail}`);
-                return next();
+
+                const permissions = userInfo[UserProfileKeys.Permissions];
+
+                if (permissions !== undefined && permissions["/admin/transaction-search"] === 1) {
+                    return next();
+                } else {
+                    logger.infoRequest(req, `Signed in user (${req.body.loggedInUserEmail}) does not have the correct permissions`);
+
+                    res.status(403);
+
+                    return res.render("notAuthorised");
+                }
             }
         }
         return res.redirect(`/signin?return_to=/${config.urlPrefix}/`);

--- a/src/test/controllers/Authentication.test.ts
+++ b/src/test/controllers/Authentication.test.ts
@@ -65,19 +65,38 @@ describe("authenticationMiddleware", function () {
         chai.expect(mockResponse.redirect.calledOnceWith(`/signin?return_to=/${mockUrl}/`)).to.be.true;
     });
 
-    it("calls next if signed in and user profile exists", function () {
+    it("calls next if signed in and user profile exists with permission", function () {
 
         const mockRequest: any = createMockRequest({
             [SignInInfoKeys.SignedIn]: 1,
                 [SignInInfoKeys.UserProfile]: {
                     [UserProfileKeys.Email]: 'email',
-                }
+                    [UserProfileKeys.Permissions]: {
+                        "/admin/transaction-search" : 1
+                    }
+                },
             });
 
         middleware(mockRequest, mockResponse, next);
 
         chai.expect(next.calledOnce).to.be.true;
     });
+
+    it("renders not authorised if signed in and user profile exists without permission", function () {
+
+        const mockRequest: any = createMockRequest({
+            [SignInInfoKeys.SignedIn]: 1,
+                [SignInInfoKeys.UserProfile]: {
+                    [UserProfileKeys.Email]: 'email'
+                },
+            });
+
+        middleware(mockRequest, mockResponse, next);
+
+        chai.expect(mockResponse.status.calledOnceWith(403)).to.be.true;
+        chai.expect(mockResponse.render.calledOnceWith("notAuthorised")).to.be.true;
+    });
+
     it("redirects to signin if signed in is set to 0", function () {
 
         const mockRequest: any = createMockRequest({

--- a/src/views/notAuthorised.html
+++ b/src/views/notAuthorised.html
@@ -1,0 +1,5 @@
+{% extends "layout.html" %}
+
+{% block content %}
+    <p>You are not authorised to access this service.</p>
+{% endblock %}


### PR DESCRIPTION
This pr adds a user permission check before logging a user into the transaction search tool. The user permission is an admin permission with title: "fes-admin-user". Also included is a not authorised page that users are redirected to without the permission.

**Resolves:**
- BI-7211