### PR TITLE
Fix failing unit test

### DIFF
--- a/src/test/controllers/Authentication.test.ts
+++ b/src/test/controllers/Authentication.test.ts
@@ -29,7 +29,7 @@ describe("authenticationMiddleware", function () {
             redirect: sinon.spy(),
             status: sinon.stub(),
             render: sinon.spy(),
-            app: { get() {}}
+            app: sinon.stub()
         };
     };
 

--- a/src/test/controllers/Authentication.test.ts
+++ b/src/test/controllers/Authentication.test.ts
@@ -28,7 +28,8 @@ describe("authenticationMiddleware", function () {
         return {
             redirect: sinon.spy(),
             status: sinon.stub(),
-            render: sinon.spy()
+            render: sinon.spy(),
+            app: { get() {}}
         };
     };
 
@@ -66,6 +67,10 @@ describe("authenticationMiddleware", function () {
     });
 
     it("calls next if signed in and user profile exists with permission", function () {
+        var engine = {
+            addGlobal: sinon.stub()
+          };
+        sinon.stub(mockResponse.app, "get").returns(engine);
 
         const mockRequest: any = createMockRequest({
             [SignInInfoKeys.SignedIn]: 1,


### PR DESCRIPTION
This PR adds an engine stub to Authentication.test to prevent a unit test from failing.

**Resolves**
BI-7724