### PR TITLE
Fix org unit and user sql and display user on results page

### DIFF
--- a/src/controllers/BarcodeSearchController.ts
+++ b/src/controllers/BarcodeSearchController.ts
@@ -60,6 +60,7 @@ class BarcodeSearchController {
     private createModel(barcode: string, chipsResult: ChipsResult, fesResult: FesResult, orgUnit: string, userLogin: string): DocumentOverviewModel {
         var model = new DocumentOverviewModel();
         model.formBarcode = barcode;
+        model.status = chipsResult.chipsStatus || fesResult.fesStatus;
         model.documentId = chipsResult.documentId;
         model.chipsStatus = chipsResult.chipsStatus;
         model.transactionId = chipsResult.transactionId;

--- a/src/models/DocumentOverviewModel.ts
+++ b/src/models/DocumentOverviewModel.ts
@@ -2,6 +2,7 @@ import BarcodeSearchModel from "./BarcodeSearchModel";
 
 class DocumentOverviewModel extends BarcodeSearchModel {
     transactionId: number;
+    status: string;
     documentId: number;
     envNo: number;
     scanTime: string;
@@ -18,10 +19,11 @@ class DocumentOverviewModel extends BarcodeSearchModel {
     public getModel(): Object {
         return {
             "Barcode" : this.formBarcode,
-            "User" : this.user,
+            "Status" : this.status,
+            "User" : this.user || "No user allocated",
             "CoNumb" : this.incorporationNumber,
             "Type" : this.formType,
-            "ChipsStatus" : this.chipsStatus,
+            "ChipsStatus" : this.chipsStatus || "Not in CHIPS",
             "FESStatus" : this.fesStatus,
             "Location" : this.orgUnit,
             "TransactionId" : this.transactionId,

--- a/src/service/ChipsService.ts
+++ b/src/service/ChipsService.ts
@@ -29,7 +29,7 @@ class ChipsService {
 
     public async getUserFromId(userId: number): Promise<string> {
         var result = await this.dao.makeQuery(SqlData.userSql, [userId]);
-        return result.rows[0]? result.rows[0]['LOGIN_ID'] : "No user allocated";
+        return result.rows[0] ? result.rows[0]['LOGIN_ID'] : "No user allocated";
     }
 }
 

--- a/src/service/ChipsService.ts
+++ b/src/service/ChipsService.ts
@@ -29,7 +29,7 @@ class ChipsService {
 
     public async getUserFromId(userId: number): Promise<string> {
         var result = await this.dao.makeQuery(SqlData.userSql, [userId]);
-        return result.rows[0]? result.rows[0]['LOGIN_ID'] : "No user assigned";
+        return result.rows[0]? result.rows[0]['LOGIN_ID'] : "No user allocated";
     }
 }
 

--- a/src/sql/SqlData.ts
+++ b/src/sql/SqlData.ts
@@ -10,15 +10,11 @@ class SqlData {
     
     public static getQueueAndUserFromDocumentSQL: string =
     `SELECT O_QUEUENAME, O_QPARAM1
-    FROM STAFFO
-    WHERE O_CASENUM = (
-        SELECT CASENUM 
-        FROM CASE_DATA 
-        WHERE FIELD_NAME = 'X_QHADOCID' 
-        AND PROC_ID = 26
-        AND FIELD_VALUE = :documentId
-        AND ROWNUM = 1
-    )
+    FROM STAFFO SO
+    INNER JOIN CASE_DATA CD
+    ON SO.O_CASENUM = CD.CASENUM
+    WHERE CD.FIELD_NAME = 'X_QHADOCID'
+    AND CD.FIELD_VALUE = :documentId
     AND ROWNUM = 1`
 
     public static orgUnitSql: string = 

--- a/src/views/documentOverview.html
+++ b/src/views/documentOverview.html
@@ -26,7 +26,7 @@
           <dt class="govuk-summary-list__key">
             CHIPS status
           </dt>
-          <dd class="govuk-summary-list__value">{{ result.ChipsStatus }}</dd>
+          <dd class="govuk-summary-list__value">{{ result.ChipsStatus }} ({{ result.User}})</dd>
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/src/views/documentOverview.html
+++ b/src/views/documentOverview.html
@@ -26,7 +26,7 @@
           <dt class="govuk-summary-list__key">
             CHIPS status
           </dt>
-          <dd class="govuk-summary-list__value">{{ result.ChipsStatus }} ({{ result.User}})</dd>
+          <dd class="govuk-summary-list__value">{{ result.ChipsStatus }} ({{ result.User }})</dd>
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/src/views/documentOverview.html
+++ b/src/views/documentOverview.html
@@ -11,7 +11,7 @@
         <div class="govuk-grid-column-one-half no-print">
           <p class="float-right">Current status:<br>
             <strong>
-              {{ result.ChipsStatus }}</strong><br>
+              {{ result.Status }}</strong><br>
             at {{ result.TransactionDate }}</p>
         </div>
       </div>
@@ -26,7 +26,7 @@
           <dt class="govuk-summary-list__key">
             CHIPS status
           </dt>
-          <dd class="govuk-summary-list__value">{% if result.ChipsStatus %}{{ result.ChipsStatus }} ({{ result.User }}){% endif %}</dd>
+          <dd class="govuk-summary-list__value">{{ result.ChipsStatus }} ({{ result.User }})</dd>
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/src/views/documentOverview.html
+++ b/src/views/documentOverview.html
@@ -26,7 +26,7 @@
           <dt class="govuk-summary-list__key">
             CHIPS status
           </dt>
-          <dd class="govuk-summary-list__value">{{ result.ChipsStatus }} ({{ result.User }})</dd>
+          <dd class="govuk-summary-list__value">{% if result.ChipsStatus %}{{ result.ChipsStatus }} ({{ result.User }}){% endif %}</dd>
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">


### PR DESCRIPTION
This pr fixes a bug where the sql used for staffware would not pick up the STAFFO record. This was due to the proc_id being hardcoded to 26 when it could be a number of values including 45. To fix this the sql has been made dynamic to look for the staffo record directly using the document id. Also the user has been displayed to match the prototype.

**Resolves:**
- BI-8103