### PR TITLE
Move email setting out of permission check

### DIFF
--- a/src/controllers/Authentication.ts
+++ b/src/controllers/Authentication.ts
@@ -28,9 +28,10 @@ const createAuthenticationMiddleware = function (): RequestHandler {
 
                 const permissions = userInfo[UserProfileKeys.Permissions];
 
+                var engine = res.app.get('engine');
+                engine.addGlobal("loggedInUserEmail", req.body.loggedInUserEmail);
+
                 if (permissions !== undefined && permissions["/admin/transaction-search"] === 1) {
-                    var engine = res.app.get('engine');
-                    engine.addGlobal("loggedInUserEmail", req.body.loggedInUserEmail);
                     return next();
                 } else {
                     logger.infoRequest(req, `Signed in user (${req.body.loggedInUserEmail}) does not have the correct permissions`);


### PR DESCRIPTION
This PR moves setting the user's email outside of the permission check block so that the user's email will always be set as long as they are logged in and the engine won't set it with another user's email from another session.

**Resolves:**
- BI-8280