### PR TITLE
Add ternary check to result image settings

### DIFF
--- a/src/service/FesService.ts
+++ b/src/service/FesService.ts
@@ -19,9 +19,9 @@ class FesService {
             result.fesStatus = fesSearch.rows[0]['FORM_STATUS_TYPE_NAME'];
             var imageSearch = await this.dao.makeQuery(SqlData.fesImageExceptionSql, [fesSearch.rows[0]['FORM_IMAGE_ID']]);
             var imageResult = imageSearch.rows[0];
-            result.icoReturnedReason = imageResult['IMAGE_EXCEPTION_REASON'] || "No image exception returned";
-            result.icoAction = imageResult['IMAGE_EXCEPTION_FREE_TEXT'] || "No image exception returned";
-            result.exceptionId = imageResult['IMAGE_EXCEPTION_ID'];
+            result.icoReturnedReason = imageResult ? imageResult['IMAGE_EXCEPTION_REASON'] : "No image exception returned";
+            result.icoAction = imageResult ? imageResult['IMAGE_EXCEPTION_FREE_TEXT'] : "No image exception returned";
+            result.exceptionId = imageResult ? imageResult['IMAGE_EXCEPTION_ID'] : "";
             if (result.exceptionId) {
                 var exceptionSearch = await this.dao.makeQuery(SqlData.fesRescannedSql, [result.exceptionId]);
                 result.eventOccurredTime = exceptionSearch.rows[0]['FORM_EVENT_OCCURED'] || "No event yet";


### PR DESCRIPTION
This PR adds a ternary check to the result image exception fields in the FES service to stop 504s when the database search returns nothing as opposed to an object with no value for said field.

**Resolves**
- BI-8241