### PR TITLE
Improve error handling

### DIFF
--- a/src/controllers/BarcodeSearchController.ts
+++ b/src/controllers/BarcodeSearchController.ts
@@ -35,6 +35,7 @@ class BarcodeSearchController {
             fesResult = await this.fesService.getTransactionDetailsFromBarcode(barcode);
         } catch(err) {
             errorHandler.handleError(this.constructor.name, "searchBarcode", err, res);
+            return;
         }
 
         var staffwareResult: StaffwareResult;
@@ -51,7 +52,7 @@ class BarcodeSearchController {
                 var userId = staffwareResult.userId || chipsResult.userAccessId;
                 userLogin = await this.chipsService.getUserFromId(userId);
             } catch(err) {
-                errorHandler.handleError(this.constructor.name, "searchBarcode", err, res);
+                errorHandler.handleError(this.constructor.name, "searchBarcode", err);
             }
             
         }

--- a/src/controllers/BarcodeSearchController.ts
+++ b/src/controllers/BarcodeSearchController.ts
@@ -7,6 +7,7 @@ import ChipsResult from "../data/ChipsResult";
 import FesService from "../service/FesService";
 import FesResult from "../data/FesResult";
 import DocumentOverviewModel from "../models/DocumentOverviewModel";
+import { errorHandler } from "../utils/ErrorHandler";
 
 const logger = createLogger(config.applicationNamespace);
 
@@ -28,21 +29,31 @@ class BarcodeSearchController {
 
     public async searchBarcode(req: any, res: any) {
         var barcode = req.query.search;
-        var chipsResult = await this.chipsService.getTransactionDetailsFromBarcode(barcode);
-        var fesResult = await this.fesService.getTransactionDetailsFromBarcode(barcode);
+        var chipsResult, fesResult;
+        try {
+            chipsResult = await this.chipsService.getTransactionDetailsFromBarcode(barcode);
+            fesResult = await this.fesService.getTransactionDetailsFromBarcode(barcode);
+        } catch(err) {
+            errorHandler.handleError(this.constructor.name, "searchBarcode", err, res);
+        }
 
         var staffwareResult: StaffwareResult;
         var orgUnit = '';
         var userLogin= '';
 
         if (chipsResult.documentId != undefined ) {
-            staffwareResult = await this.swService.addStaffwareData(chipsResult.documentId);
+            try {
+                staffwareResult = await this.swService.addStaffwareData(chipsResult.documentId);
 
-            var orgUnitId = staffwareResult.orgUnitId || chipsResult.orgUnitId;
-            orgUnit = await this.chipsService.getOrgUnitFromId(orgUnitId);
-
-            var userId = staffwareResult.userId || chipsResult.userAccessId;
-            userLogin = await this.chipsService.getUserFromId(userId);
+                var orgUnitId = staffwareResult.orgUnitId || chipsResult.orgUnitId;
+                orgUnit = await this.chipsService.getOrgUnitFromId(orgUnitId);
+    
+                var userId = staffwareResult.userId || chipsResult.userAccessId;
+                userLogin = await this.chipsService.getUserFromId(userId);
+            } catch(err) {
+                errorHandler.handleError(this.constructor.name, "searchBarcode", err, res);
+            }
+            
         }
 
         if (chipsResult.isEmpty() && fesResult.isEmpty()) {

--- a/src/daos/ParentDao.ts
+++ b/src/daos/ParentDao.ts
@@ -1,10 +1,7 @@
+import { errorHandler } from './../utils/ErrorHandler';
 import oracledb from "oracledb";
-import config from "../config";
-import { createLogger } from "ch-structured-logging";
 
 oracledb.outFormat = oracledb.OUT_FORMAT_OBJECT;
-
-const logger = createLogger(config.applicationNamespace);
 
 class ParentDao {
 
@@ -21,7 +18,7 @@ class ParentDao {
                 connectString : this.connectionString
             });
         } catch (err: any) {
-            logger.error("Error setting up connection: " + err +
+            errorHandler.handleError(this.constructor.name, "setupConnection", err +
             " username: " + this.user + " connectionString: " + this.connectionString);
         }
         return
@@ -33,7 +30,7 @@ class ParentDao {
         try {
             result = await this.connection.execute(query, bindParams);
         } catch (err: any) {
-            logger.error("Error in make query: " + err);
+            errorHandler.handleError(this.constructor.name, "makeQuery", err);
             result = null;
         } finally {
             await this.connection.close();

--- a/src/daos/ParentDao.ts
+++ b/src/daos/ParentDao.ts
@@ -18,8 +18,7 @@ class ParentDao {
                 connectString : this.connectionString
             });
         } catch (err: any) {
-            errorHandler.handleError(this.constructor.name, "setupConnection", err +
-            " username: " + this.user + " connectionString: " + this.connectionString);
+            errorHandler.handleError(this.constructor.name, "setupConnection", err);
         }
         return
     }
@@ -33,7 +32,7 @@ class ParentDao {
             errorHandler.handleError(this.constructor.name, "makeQuery", err);
             result = null;
         } finally {
-            await this.connection.close();
+            await this.connection.close().catch();
         }
         return result;
     }

--- a/src/test/daos/ChipsDao.test.ts
+++ b/src/test/daos/ChipsDao.test.ts
@@ -25,7 +25,9 @@ describe('Chips database call', () => {
     before( async ()=> {
         sinon.stub(oracledb, 'getConnection').resolves({
             execute: function() {},
-            close: function() {}
+            close: function() { 
+                    return { catch: function() {} };
+            }
         });
         let connection = await oracledb.getConnection(config);
         connection.execute = sinon.stub();

--- a/src/test/daos/FesDao.test.ts
+++ b/src/test/daos/FesDao.test.ts
@@ -25,7 +25,9 @@ describe('Fes database call', () => {
     before( async ()=> {
         sinon.stub(oracledb, 'getConnection').resolves({
             execute: function() {},
-            close: function() {}
+            close: function() { 
+                return { catch: function() {} };
+            }
         });
         let connection = await oracledb.getConnection(config);
         connection.execute = sinon.stub();

--- a/src/test/daos/StaffwareDao.test.ts
+++ b/src/test/daos/StaffwareDao.test.ts
@@ -24,7 +24,9 @@ describe('Staffware database call', () => {
     before( async ()=> {
         sinon.stub(oracledb, 'getConnection').resolves({
             execute: function() {},
-            close: function() {}
+            close: function() { 
+                return { catch: function() {} };
+            }
         });
         let connection = await oracledb.getConnection(config);
         connection.execute = sinon.stub();

--- a/src/utils/ErrorHandler.ts
+++ b/src/utils/ErrorHandler.ts
@@ -1,0 +1,13 @@
+import config from "../config";
+import { createLogger } from "ch-structured-logging";
+
+const logger = createLogger(config.applicationNamespace);
+
+class ErrorHandler {
+    public handleError(name:string, functionName: string, description: string, res?) {
+        logger.error("Error in " + name + " function " + functionName+ ": " + description);
+        res?.status(500);
+    }
+}
+
+export const errorHandler = new ErrorHandler();

--- a/src/utils/ErrorHandler.ts
+++ b/src/utils/ErrorHandler.ts
@@ -4,8 +4,8 @@ import { createLogger } from "ch-structured-logging";
 const logger = createLogger(config.applicationNamespace);
 
 class ErrorHandler {
-    public handleError(name:string, functionName: string, description: string, res?) {
-        logger.error("Error in " + name + " function " + functionName+ ": " + description);
+    public handleError(className:string, functionName: string, err: Error, res?) {
+        logger.error("Error in " + className + " function " + functionName+ ": " + err.message);
         res?.status(500);
     }
 }


### PR DESCRIPTION
This PR adds an error handler that prints out the name of the class and function it is passed, as well as the error, whenever an error is thrown. The handler will also, when possible, throw a status 500.
Chained catch methods were added to down flow promises to plug any unresolved promise issues caused by thrown errors.

**Resolves:**
- BI-8243