### PR TITLE
Add empty check on casenum for staffware result

### DIFF
--- a/src/handlers/BarcodeSearchHandler.ts
+++ b/src/handlers/BarcodeSearchHandler.ts
@@ -140,7 +140,7 @@ class BarcodeSearchHandler {
 
         try {
             fesTimelineResults = await this.fesService.getFesTimelineDetails(barcode);
-            staffwareResult = await this.swService.getAuditDate(docModel.casenum);
+            staffwareResult = docModel.casenum ? await this.swService.getAuditDate(docModel.casenum) : new StaffwareResult();
         } catch(err) {
             errorHandler.handleError(this.constructor.name, "getTimelineResult", err);
             return timelineModel;


### PR DESCRIPTION
This pr checks whether there is a casenum before making a call to retrieve staffware timeline data. This is to stop a null pointer exception breaking the timeline if there is no staffware case.

**Resolves:**
- BI-10078