### PR TITLE
ASM-1484: Default rather than hardwire the port the app listens on

### DIFF
--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 # Start script for transaction-search-tool
 
+# Default port to 18580 for the docker-chs-development environment.
+export PORT=${PORT:-18580}
+
 npm run chs-dev

--- a/ecs-image-build/docker_start.sh
+++ b/ecs-image-build/docker_start.sh
@@ -2,6 +2,7 @@
 #
 # Start script for transaction search tool
 
-PORT=3000
+# Default port to 3000 for ECS environments.
+PORT=${PORT:-3000}
 
 exec node /opt/dist/app/app.js -- ${PORT}


### PR DESCRIPTION
* This is done for the following reasons:

1. It should make it possible to run up the app so that it works correctly in `docker-chs-development`, even when the app is not in development mode.
2. It means setting the value `- PORT=XXXXX` in the `docker-compose` file has the expected impact on the app when run in `docker-chs-development`.