### PR TITLE
ASM-1484: Defaulted PORT value must be exported

### DIFF
--- a/ecs-image-build/docker_start.sh
+++ b/ecs-image-build/docker_start.sh
@@ -3,6 +3,6 @@
 # Start script for transaction search tool
 
 # Default port to 3000 for ECS environments.
-PORT=${PORT:-3000}
+export PORT=${PORT:-3000}
 
-exec node /opt/dist/app/app.js -- ${PORT}
+exec node /opt/dist/app/app.js


### PR DESCRIPTION
Changes made here:

1. If the defaulted value is not exported, then the app does not pick up the defaulted value. Hence, it is now exported.
2. Removed the command line suffix `-- ${PORT}` as it appears to have no impact on the app.