### PR TITLE
ASM-1484: Use CommonJS syntax in eslint.config.js to avoid lint warning

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,9 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import eslint from "@eslint/js";
-import parser from "@typescript-eslint/parser"
-import tseslint from 'typescript-eslint';
+const { defineConfig } = require("eslint/config");
+const eslint = require("@eslint/js");
+const parser  = require("@typescript-eslint/parser");
+const tseslint = require('typescript-eslint');
 
-export default defineConfig([
+module.exports = defineConfig([
     eslint.configs.recommended,
     tseslint.configs.recommended,
     {


### PR DESCRIPTION
This change of syntax avoids this warning previously seen when `npm run lint` was invoked:

```
(node:38) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///tmp/build/7e02c15e/node-code/eslint.config.js?mtime=1775041690000 is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /tmp/build/7e02c15e/node-code/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
```